### PR TITLE
Adjust spacing for calendar dot indicator

### DIFF
--- a/webview/calendar.css
+++ b/webview/calendar.css
@@ -72,7 +72,7 @@ body {
 .day-cell.has-notes::after {
     content: '';
     position: absolute;
-    bottom: 3px;
+    bottom: 1px;
     left: 50%;
     transform: translateX(-50%);
     width: 5px;


### PR DESCRIPTION
## Summary
- tweak CSS so the notes indicator dot has a little space below the date number

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6839141ed6088332b4b10f4c8bd4072f